### PR TITLE
Remove impredicative types

### DIFF
--- a/src/Data/Dependent/Sum.hs
+++ b/src/Data/Dependent/Sum.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE ExistentialQuantification, GADTs #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
@@ -148,7 +146,7 @@ instance Read (f a) => ReadTag ((:=) a) f where
 instance ReadTag tag f => Read (DSum tag f) where
     readsPrec p = readParen (p > 1) $ \s -> 
         concat
-            [ withTag $ \tag ->
+            [ getGReadResult withTag $ \tag ->
                 [ (tag :=> val, rest'')
                 | (val, rest'') <- readTaggedPrec tag 1 rest'
                 ]

--- a/src/Data/GADT/Compare.hs
+++ b/src/Data/GADT/Compare.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-deprecated-flags #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE PolyKinds #-}
@@ -57,8 +56,8 @@ instance GShow ((:=) a) where
 instance GRead ((:=) a) where
     greadsPrec p s = readsPrec p s >>= f
         where
-            f :: forall x. (x := x, String) -> [(forall b. (forall a. x := a -> b) -> b, String)]
-            f (Refl, rest) = return ((\x -> x Refl) :: forall b. (forall a. x := a -> b) -> b, rest)
+            f :: forall x. (x := x, String) -> [(GReadResult ((:=) x), String)]
+            f (Refl, rest) = return (GReadResult (\x -> x Refl) , rest)
 
 -- |A class for type-contexts which contain enough information
 -- to (at least in some cases) decide the equality of types 
@@ -154,9 +153,9 @@ instance GShow (GOrdering a) where
 
 instance GRead (GOrdering a) where
     greadsPrec _ s = case con of
-        "GGT"   -> [(\x -> x GGT, rest)]
-        "GEQ"   -> [(\x -> x GEQ, rest)]
-        "GLT"   -> [(\x -> x GLT, rest)]
+        "GGT"   -> [(GReadResult (\x -> x GGT), rest)]
+        "GEQ"   -> [(GReadResult (\x -> x GEQ), rest)]
+        "GLT"   -> [(GReadResult (\x -> x GLT), rest)]
         _       -> []
         where (con, rest) = splitAt 3 s
 
@@ -170,5 +169,3 @@ instance GCompare ((:=) a) where
 
 defaultCompare :: GCompare f => f a -> f b -> Ordering
 defaultCompare x y = weakenOrdering (gcompare x y)
-
-

--- a/src/Data/Some.hs
+++ b/src/Data/Some.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
@@ -28,7 +27,7 @@ instance GShow tag => Show (Some tag) where
 
 instance GRead f => Read (Some f) where
     readsPrec p = readParen (p>10) $ \s ->
-        [ (withTag This, rest')
+        [ (getGReadResult withTag This, rest')
         | let (con, rest) = splitAt 5 s
         , con == "This "
         , (withTag, rest') <- greadsPrec 11 rest


### PR DESCRIPTION
Since the `ImpredicativeTypes` extension is chronically broken,
it seems better to avoid it when possible. In this case,
doing so requires a `newtype` wrapper around `GRead` results.
