### PR TITLE
Make Some more faithfully imitate a datatype

### DIFF
--- a/dependent-sum/src/Data/Some.hs
+++ b/dependent-sum/src/Data/Some.hs
@@ -51,12 +51,13 @@ import Unsafe.Coerce (unsafeCoerce)
 -- Some TagBool
 --
 newtype Some tag = UnsafeSome (tag Any)
+data SBox a = SBox !a
 
 #if __GLASGOW_HASKELL__ >= 801
 {-# COMPLETE Some #-}
 #endif
 pattern Some :: tag a -> Some tag
-pattern Some x <- UnsafeSome ((unsafeCoerce :: tag Any -> tag a) -> x)
+pattern Some x <- UnsafeSome (SBox . (unsafeCoerce :: tag Any -> tag a) -> SBox x)
   where Some x = UnsafeSome ((unsafeCoerce :: tag a -> tag Any) x)
 
 #if __GLASGOW_HASKELL__ >= 801


### PR DESCRIPTION
As I understand it, the ideal implementation would be

```haskell
data Some tag = forall x. Some !(tag x)
```

but winning a `newtype`-like representation for efficiency. But to imitate this faithfully, matching on the `Some` constructor needs to force the contents.