### PR TITLE
Remove one unsafeCoerce

### DIFF
--- a/dependent-sum/src/Data/Some.hs
+++ b/dependent-sum/src/Data/Some.hs
@@ -56,8 +56,16 @@ newtype Some tag = UnsafeSome (tag Any)
 {-# COMPLETE Some #-}
 #endif
 pattern Some :: tag a -> Some tag
+#if __GLASGOW_HASKELL__ >= 802
+pattern Some x <- UnsafeSome x
+  where Some x = UnsafeSome ((unsafeCoerce :: tag a -> tag Any) x)
+#else
+-- There was a bug type checking pattern synonyms that prevented the
+-- obvious thing from working.
 pattern Some x <- UnsafeSome ((unsafeCoerce :: tag Any -> tag a) -> x)
   where Some x = UnsafeSome ((unsafeCoerce :: tag a -> tag Any) x)
+#endif
+
 
 #if __GLASGOW_HASKELL__ >= 801
 {-# COMPLETE This #-}


### PR DESCRIPTION
We need `unsafeCoerce` to stick a value *into* `Some`, but we
don't need one to take a value out. The consumer of the match
has to be ready for *any* type, and `Any` will do the trick.