### PR TITLE
update .cabal files

### DIFF
--- a/dependent-sum-template/dependent-sum-template.cabal
+++ b/dependent-sum-template/dependent-sum-template.cabal
@@ -1,5 +1,5 @@
 name:                   dependent-sum-template
-version:                0.1.0.0
+version:                0.1.0.1
 stability:              experimental
 
 cabal-version:          >= 1.8
@@ -17,13 +17,14 @@ description:            Template Haskell code to generate instances of classes i
 tested-with:            GHC == 8.0.2,
                         GHC == 8.2.2,
                         GHC == 8.4.4,
-                        GHC == 8.6.5
+                        GHC == 8.6.5,
+                        GHC == 8.8.3
 
 extra-source-files:     ChangeLog.md
 
 source-repository head
   type: git
-  location: https://github.com/mokus0/dependent-sum-template
+  location: https://github.com/mokus0/dependent-sum
 
 Library
   if impl(ghc < 7.10)

--- a/dependent-sum/dependent-sum.cabal
+++ b/dependent-sum/dependent-sum.cabal
@@ -1,5 +1,5 @@
 name:                   dependent-sum
-version:                0.6.2.0
+version:                0.6.2.1
 stability:              provisional
 
 cabal-version:          1.22
@@ -27,7 +27,8 @@ description:            A dependent sum is a generalization of a
 tested-with:            GHC == 8.0.2,
                         GHC == 8.2.2,
                         GHC == 8.4.4,
-                        GHC == 8.6.5
+                        GHC == 8.6.5,
+                        GHC == 8.8.3
 
 extra-source-files:     ChangeLog.md
                       , examples/*.hs


### PR DESCRIPTION
- proper upstream URL for dependent-sum-template
- bump versions
- tested with 8.8.3

This prepares dependent-sum and dependent-sum-template for a new hackage release. Feel free to adapt or make the changes yourself as needed.

@3noch @apollounicorn: mentioning you at request by @ryantrinkle 