### PR TITLE
Prefer canonical return definition

### DIFF
--- a/dependent-sum-template/src/Data/GADT/Compare/TH.hs
+++ b/dependent-sum-template/src/Data/GADT/Compare/TH.hs
@@ -76,11 +76,11 @@ newtype GComparing a b t = GComparing (Either (GOrdering a b) t)
 
 instance Functor (GComparing a b) where fmap f (GComparing x) = GComparing (either Left (Right . f) x)
 instance Monad (GComparing a b) where
-    return = GComparing . Right
+    return = pure
     GComparing (Left  x) >>= f = GComparing (Left x)
     GComparing (Right x) >>= f = f x
 instance Applicative (GComparing a b) where
-    pure = return
+    pure = GComparing . Right
     (<*>) = ap
 
 geq' :: GCompare t => t a -> t b -> GComparing x y (a :~: b)


### PR DESCRIPTION
With GHC 9.2 the following warning is shown:

``` 
src/Data/GADT/Compare/TH.hs:79:5: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘return’ definition detected
    in the instance declaration for ‘Monad (GComparing a b)’.
    ‘return’ will eventually be removed in favour of ‘pure’
    Either remove definition for ‘return’ (recommended) or define as ‘return = pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
   |
79 |     return = GComparing . Right
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/GADT/Compare/TH.hs:83:5: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘pure = return’ definition detected
    in the instance declaration for ‘Applicative (GComparing a b)’.
    Move definition from ‘return’ to ‘pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
   |
83 |     pure = return
   | 
``` 

We fix it here so no one else has to later