### PR TITLE
dependent-sum-template: add lowerbound for th-abstraction

### DIFF
--- a/dependent-sum-template/dependent-sum-template.cabal
+++ b/dependent-sum-template/dependent-sum-template.cabal
@@ -39,7 +39,7 @@ Library
                         dependent-sum >= 0.4.1 && < 0.8,
                         template-haskell,
                         th-extras >= 0.0.0.2,
-                        th-abstraction
+                        th-abstraction >= 0.4
 
 test-suite test
   if impl(ghc < 8.0)


### PR DESCRIPTION
Language.Haskell.TH.Datatype.TyVarBndr was introduced in th-abstraction-0.4.0.0
So the build fails with th-abstraction-0.3