### PR TITLE
dependent-sum-template: Narrow dependency to just `some`

### DIFF
--- a/dependent-sum-template/ChangeLog.md
+++ b/dependent-sum-template/ChangeLog.md
@@ -6,6 +6,8 @@
   normalize their representation. This should allow the deriving functions to work on a much wider range
   of types.
 
+* Change dependency to just be on `some`, not `dependent-sum`, as we just need the reexported classes.
+
 ## 0.1.1.1 - 2021-12-30
 
 * Fix warning with GHC 9.2 about non-canonical `return`.

--- a/dependent-sum-template/dependent-sum-template.cabal
+++ b/dependent-sum-template/dependent-sum-template.cabal
@@ -11,8 +11,8 @@ license:                PublicDomain
 homepage:               https://github.com/obsidiansystems/dependent-sum
 
 category:               Unclassified
-synopsis:               Template Haskell code to generate instances of classes in dependent-sum package
-description:            Template Haskell code to generate instances of classes in dependent-sum package, such as 'GEq' and 'GCompare'.
+synopsis:               Template Haskell code to generate instances of classes in some package
+description:            Template Haskell code to generate instances of classes in some package, such as 'GEq' and 'GCompare'.
 
 tested-with:            GHC == 8.0.2,
                         GHC == 8.2.2,
@@ -37,7 +37,7 @@ Library
   other-modules:        Data.Dependent.Sum.TH.Internal
                         Data.GADT.Compare.Monad
   build-depends:        base >= 3 && <5,
-                        dependent-sum >= 0.4.1 && < 0.8,
+                        some >= 1.0.1 && < 1.1,
                         containers >= 0.5.9.2,
                         mtl,
                         template-haskell,
@@ -52,7 +52,7 @@ test-suite test
   main-is: test.hs
   build-depends: base
                , constraints-extras
-               , dependent-sum
                , dependent-sum-template
                , template-haskell
+               , some
                , th-abstraction

--- a/dependent-sum-template/src/Data/GADT/Compare/TH.hs
+++ b/dependent-sum-template/src/Data/GADT/Compare/TH.hs
@@ -14,7 +14,6 @@ module Data.GADT.Compare.TH
 
 import Control.Monad
 import Control.Monad.Writer
-import Data.Dependent.Sum
 import Data.Dependent.Sum.TH.Internal
 import Data.Functor.Identity
 import Data.GADT.Compare

--- a/dependent-sum-template/src/Data/GADT/Show/TH.hs
+++ b/dependent-sum-template/src/Data/GADT/Show/TH.hs
@@ -6,7 +6,6 @@ module Data.GADT.Show.TH
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Writer
-import Data.Dependent.Sum
 import Data.Dependent.Sum.TH.Internal
 import Data.Functor.Identity
 import Data.GADT.Show

--- a/dependent-sum-template/test/test.hs
+++ b/dependent-sum-template/test/test.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -ddump-splices #-}
 import Control.Monad
-import Data.Dependent.Sum
 import Data.Functor.Identity
 import Data.Constraint.Extras.TH
 import Data.GADT.Compare


### PR DESCRIPTION
We just use the reexported classes, so `dependent-sum` is overkill.