### PR TITLE
Test higher-arity type constructors

### DIFF
--- a/dependent-sum-template/src/Data/Dependent/Sum/TH/Internal.hs
+++ b/dependent-sum-template/src/Data/Dependent/Sum/TH/Internal.hs
@@ -10,18 +10,18 @@
 -- | Shared functions for dependent-sum-template
 module Data.Dependent.Sum.TH.Internal where
 
+import Control.Monad
+import Control.Monad.Writer
+import Data.List (foldl', drop)
+import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Lazy as Map
-import Language.Haskell.TH.Datatype
-
-import Data.Maybe
-import Control.Monad
-import Control.Monad.Writer
-import Language.Haskell.TH
-import Language.Haskell.TH.Datatype.TyVarBndr
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Language.Haskell.TH
+import Language.Haskell.TH.Datatype
+import Language.Haskell.TH.Datatype.TyVarBndr
 
 classHeadToParams :: Type -> (Name, [Type])
 classHeadToParams t = (h, reverse reversedParams)

--- a/dependent-sum-template/test/test.hs
+++ b/dependent-sum-template/test/test.hs
@@ -209,3 +209,17 @@ do
         ]
 
 instance Show (Fnord a) where showsPrec = gshowsPrec
+
+
+data MyTest a :: * -> * where
+  MyTest_1 :: MyTest a ()
+  MyTest_2 :: MyTest a Int
+
+deriving instance Eq (MyTest a b)
+deriving instance Ord (MyTest a b)
+deriving instance Show (MyTest a b)
+
+deriveGShow ''MyTest
+deriveGEq ''MyTest
+deriveGCompare ''MyTest
+deriveArgDict ''MyTest


### PR DESCRIPTION
Got some arity kind error when trying to use a `MyGadt a :: * -> *`, and this seems to make the kinds line up, though I'm not sure if it's the right fix. The `makeClassHead` parameter doesn't seem the right way to go about it, but that's for `DataD`. I'm not so sure about the other `Dec` cases. For instance, I don't get the intent for `InstanceD` at all - we're modifying instances?
