### PR TITLE
Allow some 1.0.6

### DIFF
--- a/dependent-sum/dependent-sum.cabal
+++ b/dependent-sum/dependent-sum.cabal
@@ -49,7 +49,7 @@ Library
                       , constraints-extras >= 0.2 && < 0.5
 
   -- tight bounds, so re-exported API is versioned properly.
-  build-depends:        some >= 1.0.4 && < 1.0.6
+  build-depends:        some >= 1.0.4 && < 1.0.7
 
   if impl(ghc >= 7.2)
     ghc-options:        -trust base


### PR DESCRIPTION
which is mostly a maintenance release for GHC9.6.3 and GHC9.8.

Changelog says
```
Add instances for SSymbol, SNat and SChar from `base >=4.18.0.0'
```

Compiles happily on GHC9.4.7.